### PR TITLE
Show restricting SIDs when displaying the access token property page.

### DIFF
--- a/ProcessHacker/include/phapp.h
+++ b/ProcessHacker/include/phapp.h
@@ -789,7 +789,8 @@ VOID PhShowThreadStackDialog(
 // tokprp
 
 PPH_STRING PhGetGroupAttributesString(
-    _In_ ULONG Attributes
+    _In_ ULONG Attributes,
+    _In_ BOOLEAN Restricted
     );
 
 PWSTR PhGetPrivilegeAttributesString(

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -350,6 +350,14 @@ PhGetTokenGroups(
 PHLIBAPI
 NTSTATUS
 NTAPI
+PhGetTokenRestrictedSids(
+    _In_ HANDLE TokenHandle,
+    _Out_ PTOKEN_GROUPS* RestrictedSids
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
 PhGetTokenPrivileges(
     _In_ HANDLE TokenHandle,
     _Out_ PTOKEN_PRIVILEGES *Privileges

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -1869,6 +1869,25 @@ NTSTATUS PhGetTokenGroups(
 }
 
 /**
+ * Get a token's restricted SIDs.
+ *
+ * \param TokenHandle A handle to a token. The handle must have TOKEN_QUERY access.
+ * \param RestrictedSids A variable which receives a pointer to a structure containing the token's restricted SIDs.
+ * You must free the structure using PhFree() when you no longer need it.
+ */
+NTSTATUS PhGetTokenRestrictedSids(
+    _In_ HANDLE TokenHandle,
+    _Out_ PTOKEN_GROUPS* RestrictedSids
+)
+{
+    return PhpQueryTokenVariableSize(
+        TokenHandle,
+        TokenRestrictedSids,
+        RestrictedSids
+        );
+}
+
+/**
  * Gets a token's privileges.
  *
  * \param TokenHandle A handle to a token. The handle must have TOKEN_QUERY access.


### PR DESCRIPTION
The `CreateRestrictedToken` / `NtFilterToken` APIs allow adding a set of 'restricted SIDs' to an access token. Whenever an access check on a securable object occurs, access is first checked only with a token's enabled SIDs. Then, access is checked again only with a token's restricted SIDs. If both access checks pass, access to the object is granted.

Process Hacker currently does not display a token's restricted SIDs, unlike other tools, such as Process Explorer. See screenshot:

![procexp_ph_restricted_sids](https://user-images.githubusercontent.com/720852/29250301-240b8eda-8049-11e7-8ff5-e4efbefd8f9a.png)

This PR adds token restricted SIDs to the token property page. The restricted SIDs are added to the same list view as the existing token groups view, since the vast majority of tokens do not have any restricted SIDs.

This is how a token with some restricted SID appears after this change:

![after_restricted_sids](https://user-images.githubusercontent.com/720852/29250347-bac9f2da-8049-11e7-9b27-39a7049c303d.png)

