### PR TITLE
Free token restricted SIDs when destroying the token property page.

### DIFF
--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -624,6 +624,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
             PhSaveListViewColumnsToSetting(L"TokenPrivilegesListViewColumns", tokenPageContext->PrivilegesListViewHandle);
 
             if (tokenPageContext->Groups) PhFree(tokenPageContext->Groups);
+            if (tokenPageContext->RestrictedSids) PhFree(tokenPageContext->RestrictedSids);
             if (tokenPageContext->Privileges) PhFree(tokenPageContext->Privileges);
         }
         break;


### PR DESCRIPTION
My PR #167 introduced a memory leak by failing to free the new restricted SIDs field when the token property page is destroyed. This adds the missing free.
