### PR TITLE
Improve security dialog AppContainer SID<>Name mappings

### DIFF
--- a/phlib/include/secedit.h
+++ b/phlib/include/secedit.h
@@ -59,7 +59,10 @@ FORCEINLINE ACCESS_MASK PhGetAccessForGetSecurity(
     if (
         (SecurityInformation & OWNER_SECURITY_INFORMATION) ||
         (SecurityInformation & GROUP_SECURITY_INFORMATION) ||
-        (SecurityInformation & DACL_SECURITY_INFORMATION)
+        (SecurityInformation & DACL_SECURITY_INFORMATION) ||
+        (SecurityInformation & LABEL_SECURITY_INFORMATION) ||
+        (SecurityInformation & ATTRIBUTE_SECURITY_INFORMATION) ||
+        (SecurityInformation & SCOPE_SECURITY_INFORMATION)
         )
     {
         access |= READ_CONTROL;
@@ -68,6 +71,11 @@ FORCEINLINE ACCESS_MASK PhGetAccessForGetSecurity(
     if (SecurityInformation & SACL_SECURITY_INFORMATION)
     {
         access |= ACCESS_SYSTEM_SECURITY;
+    }
+
+    if (SecurityInformation & BACKUP_SECURITY_INFORMATION)
+    {
+        access |= READ_CONTROL | ACCESS_SYSTEM_SECURITY;
     }
 
     return access;
@@ -81,20 +89,36 @@ FORCEINLINE ACCESS_MASK PhGetAccessForSetSecurity(
 
     if (
         (SecurityInformation & OWNER_SECURITY_INFORMATION) ||
-        (SecurityInformation & GROUP_SECURITY_INFORMATION)
+        (SecurityInformation & GROUP_SECURITY_INFORMATION) ||
+        (SecurityInformation & LABEL_SECURITY_INFORMATION)
         )
     {
         access |= WRITE_OWNER;
     }
 
-    if (SecurityInformation & DACL_SECURITY_INFORMATION)
+    if (
+        (SecurityInformation & DACL_SECURITY_INFORMATION) ||
+        (SecurityInformation & ATTRIBUTE_SECURITY_INFORMATION) ||
+        (SecurityInformation & PROTECTED_DACL_SECURITY_INFORMATION) ||
+        (SecurityInformation & UNPROTECTED_DACL_SECURITY_INFORMATION)
+        )
     {
         access |= WRITE_DAC;
     }
 
-    if (SecurityInformation & SACL_SECURITY_INFORMATION)
+    if (
+        (SecurityInformation & SACL_SECURITY_INFORMATION) ||
+        (SecurityInformation & SCOPE_SECURITY_INFORMATION) ||
+        (SecurityInformation & PROTECTED_SACL_SECURITY_INFORMATION) ||
+        (SecurityInformation & UNPROTECTED_SACL_SECURITY_INFORMATION)
+        )
     {
         access |= ACCESS_SYSTEM_SECURITY;
+    }
+
+    if (SecurityInformation & BACKUP_SECURITY_INFORMATION)
+    {
+        access |= WRITE_DAC | WRITE_OWNER | ACCESS_SYSTEM_SECURITY;
     }
 
     return access;

--- a/phlib/include/seceditp.h
+++ b/phlib/include/seceditp.h
@@ -34,6 +34,8 @@ typedef struct
 
     ULONG SidCount;
     PSID *Sids;
+
+    PPH_LIST NameCache;
 } PhSecurityIDataObject;
 
 ISecurityInformation *PhSecurityInformation_Create(
@@ -135,8 +137,8 @@ HRESULT STDMETHODCALLTYPE PhSecurityInformation2_LookupSids(
 
 HRESULT STDMETHODCALLTYPE PhSecurityDataObject_QueryInterface(
     _In_ IDataObject *This,
-    _In_ REFIID riid,
-    _Out_ PVOID *ppvObject
+    _In_ REFIID Riid,
+    _Out_ PVOID *Object
     );
 
 ULONG STDMETHODCALLTYPE PhSecurityDataObject_AddRef(

--- a/phlib/include/seceditp.h
+++ b/phlib/include/seceditp.h
@@ -19,6 +19,23 @@ typedef struct
     BOOLEAN IsPage;
 } PhSecurityInformation;
 
+typedef struct
+{
+    ISecurityInformation2Vtbl *VTable;
+
+    ULONG RefCount;
+} PhSecurityInformation2;
+
+typedef struct
+{
+    IDataObjectVtbl *VTable;
+
+    ULONG RefCount;
+
+    ULONG SidCount;
+    PSID *Sids;
+} PhSecurityIDataObject;
+
 ISecurityInformation *PhSecurityInformation_Create(
     _In_ PWSTR ObjectName,
     _In_ PPH_GET_OBJECT_SECURITY GetObjectSecurity,
@@ -88,6 +105,99 @@ HRESULT STDMETHODCALLTYPE PhSecurityInformation_PropertySheetPageCallback(
     _In_ HWND hwnd,
     _In_ UINT uMsg,
     _In_ SI_PAGE_TYPE uPage
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityInformation2_QueryInterface(
+    _In_ ISecurityInformation2 *This,
+    _In_ REFIID Riid,
+    _Out_ PVOID *Object
+    );
+
+ULONG STDMETHODCALLTYPE PhSecurityInformation2_AddRef(
+    _In_ ISecurityInformation2 *This
+    );
+
+ULONG STDMETHODCALLTYPE PhSecurityInformation2_Release(
+    _In_ ISecurityInformation2 *This
+    );
+
+BOOL STDMETHODCALLTYPE PhSecurityInformation2_IsDaclCanonical(
+    _In_ ISecurityInformation2 *This,
+    _In_ PACL pDacl
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityInformation2_LookupSids(
+    _In_ ISecurityInformation2 *This,
+    _In_ ULONG cSids,
+    _In_ PSID *rgpSids,
+    _Out_ LPDATAOBJECT *ppdo
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_QueryInterface(
+    _In_ IDataObject *This,
+    _In_ REFIID riid,
+    _Out_ PVOID *ppvObject
+    );
+
+ULONG STDMETHODCALLTYPE PhSecurityDataObject_AddRef(
+    _In_ IDataObject *This
+    );
+
+ULONG STDMETHODCALLTYPE PhSecurityDataObject_Release(
+    _In_ IDataObject *This
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetData(
+    _In_ IDataObject *This,
+    _In_ FORMATETC *pformatetcIn,
+    _Out_ STGMEDIUM *pmedium);
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetDataHere(
+    IDataObject *This,
+    _In_ FORMATETC *pformatetc,
+    _Inout_ STGMEDIUM *pmedium
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_QueryGetData(
+    _In_ IDataObject *This,
+    _In_opt_ FORMATETC *pformatetc
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetCanonicalFormatEtc(
+    _In_ IDataObject *This,
+    _In_opt_ FORMATETC *pformatectIn,
+    _Out_ FORMATETC *pformatetcOut
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_SetData(
+    _In_ IDataObject *This,
+    _In_ FORMATETC *pformatetc,
+    _In_ STGMEDIUM *pmedium,
+    _In_ BOOL fRelease
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_EnumFormatEtc(
+    _In_ IDataObject *This,
+    _In_ ULONG dwDirection,
+    _Out_opt_ IEnumFORMATETC **ppenumFormatEtc
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_DAdvise(
+    _In_ IDataObject *This,
+    _In_ FORMATETC *pformatetc,
+    _In_ ULONG advf,
+    _In_opt_ IAdviseSink *pAdvSink,
+    _Out_ ULONG *pdwConnection
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_DUnadvise(
+    _In_ IDataObject *This,
+    _In_ ULONG dwConnection
+    );
+
+HRESULT STDMETHODCALLTYPE PhSecurityDataObject_EnumDAdvise(
+    _In_ IDataObject *This,
+    _Out_opt_ IEnumSTATDATA **ppenumAdvise
     );
 
 #endif

--- a/phlib/secedit.c
+++ b/phlib/secedit.c
@@ -545,11 +545,6 @@ HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetData(
 
         sidInfo.pSid = this->Sids[i];
 
-        if (IsWellKnownSid(sidInfo.pSid, WinBuiltinAdministratorsSid))
-        {
-            sidInfoList->aSidInfo[i] = sidInfo;
-        }
-
         if (sidString = PhGetSidFullName(sidInfo.pSid, FALSE, &sidUse))
         {
             switch (sidUse)

--- a/phlib/secedit.c
+++ b/phlib/secedit.c
@@ -276,9 +276,10 @@ HRESULT STDMETHODCALLTYPE PhSecurityInformation_GetObjectInformation(
         SI_EDIT_AUDITS |
         SI_EDIT_OWNER |
         SI_EDIT_PERMS |
-        SI_ADVANCED |
+        SI_EDIT_PROPERTIES |
+        SI_ADVANCED;
         //SI_NO_ACL_PROTECT |
-        SI_NO_TREE_APPLY;
+        //SI_NO_TREE_APPLY;
     ObjectInfo->hInstance = NULL;
     ObjectInfo->pszObjectName = this->ObjectName->Buffer;
 
@@ -527,12 +528,12 @@ HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetData(
     _In_ IDataObject *This,
     _In_ FORMATETC *pformatetcIn,
     _Out_ STGMEDIUM *pmedium
-)
+    )
 {
     PhSecurityIDataObject *this = (PhSecurityIDataObject *)This;
     PSID_INFO_LIST sidInfoList;
 
-    sidInfoList = (PSID_INFO_LIST)GlobalAlloc(GMEM_FIXED | GMEM_ZEROINIT, sizeof(SID_INFO_LIST) + (sizeof(SID_INFO) * this->SidCount));
+    sidInfoList = (PSID_INFO_LIST)GlobalAlloc(GMEM_ZEROINIT, sizeof(SID_INFO_LIST) + (sizeof(SID_INFO) * this->SidCount));
     sidInfoList->cItems = this->SidCount;
 
     for (ULONG i = 0; i < this->SidCount; i++)
@@ -549,10 +550,11 @@ HRESULT STDMETHODCALLTYPE PhSecurityDataObject_GetData(
         {
             switch (sidUse)
             {
-            case SidTypeAlias:
             case SidTypeUser:
+            case SidTypeLogonSession:
                 sidInfo.pwzClass = L"User";
                 break;
+            case SidTypeAlias:
             case SidTypeGroup:
                 sidInfo.pwzClass = L"Group";
                 break;


### PR DESCRIPTION
At present appcontainer SIDs are shown as "Account Unknown" when viewing permissions for processes, tokens and handles using the security editor. 

This PR implements the ISecurityInformation2 interface and preforms SID name lookups for the permission dialogs and correctly translates the AppContainer SID into the package name.

