### PR TITLE
Fix some TEB field offsets on 32 bit

### DIFF
--- a/phnt/include/ntpebteb.h
+++ b/phnt/include/ntpebteb.h
@@ -202,7 +202,11 @@ typedef struct _TEB
     LCID CurrentLocale;
     ULONG FpSoftwareStatusRegister;
     PVOID ReservedForDebuggerInstrumentation[16];
+#ifdef _WIN64
     PVOID SystemReserved1[30];
+#else
+    PVOID SystemReserved1[26];
+#endif
     
     CHAR PlaceholderCompatibilityMode;
     CHAR PlaceholderReserved[11];
@@ -216,9 +220,15 @@ typedef struct _TEB
     ULONG_PTR InstrumentationCallbackSp;
     ULONG_PTR InstrumentationCallbackPreviousPc;
     ULONG_PTR InstrumentationCallbackPreviousSp;
+#ifdef _WIN64
     ULONG TxFsContext;
+#endif
 
     BOOLEAN InstrumentationCallbackDisabled;
+#ifndef _WIN64
+    UCHAR SpareBytes[23];
+    ULONG TxFsContext;
+#endif
     GDI_TEB_BATCH GdiTebBatch;
     CLIENT_ID RealClientId;
     HANDLE GdiCachedProcessHandle;


### PR DESCRIPTION
After updating to the RS3 types I noticed that the `LastStatusValue` field in the TEB (which is fairly far from the start of the struct) was wrong. After dumping the RS3 structs in WinDbg I arrived at this fix which adds some `#ifdef`s to match the offsets found in the debug symbols.

Going back to earlier kernel PDBs I see that some 'reserved'/padding fields (e.g. `SystemReserved1`) have always had different array sizes on 32 bit compared to 64, so it's possible the offsets were already incorrect prior to this and the RS3 changes are unrelated. I just happened to notice it now.