### PR TITLE
Tagging Apiset memory page

### DIFF
--- a/ProcessHacker/include/memprv.h
+++ b/ProcessHacker/include/memprv.h
@@ -22,7 +22,8 @@ typedef enum _PH_MEMORY_REGION_TYPE
     HeapSegmentRegion,
     HeapSegment32Region,
     CfgBitmapRegion,
-    CfgBitmap32Region
+    CfgBitmap32Region,
+    ApiSetMapRegion,
 } PH_MEMORY_REGION_TYPE;
 
 typedef struct _PH_MEMORY_ITEM

--- a/ProcessHacker/memlist.c
+++ b/ProcessHacker/memlist.c
@@ -462,6 +462,8 @@ PPH_STRING PhGetMemoryRegionUseText(
     case CfgBitmap32Region:
         return PhFormatString(L"CFG Bitmap%s",
             type == CfgBitmap32Region ? L" 32-bit" : L"");
+    case ApiSetMapRegion:
+		return PhFormatString(L"API Set schema");
     default:
         return PhReferenceEmptyString();
     }

--- a/ProcessHacker/memprv.c
+++ b/ProcessHacker/memprv.c
@@ -534,6 +534,31 @@ NTSTATUS PhpUpdateMemoryRegionTypes(
     }
 #endif
 
+
+    // ApiSet schema map
+    {
+		PVOID peb;
+		PVOID apiSetMap;
+		PROCESS_BASIC_INFORMATION basicInfo;
+
+
+		if (NT_SUCCESS(PhGetProcessBasicInformation(ProcessHandle, &basicInfo)) && basicInfo.PebBaseAddress != 0)
+		{
+			peb = basicInfo.PebBaseAddress;
+
+			if (NT_SUCCESS(NtReadVirtualMemory(
+				ProcessHandle,
+				PTR_ADD_OFFSET(peb, FIELD_OFFSET(PEB, ApiSetMap)),
+				&apiSetMap,
+				sizeof(PVOID),
+				NULL
+			)))
+			{
+				PhpSetMemoryRegionType(List, apiSetMap, TRUE, ApiSetMapRegion);
+			}
+		}
+	}
+
     PhFree(processes);
 
     return STATUS_SUCCESS;


### PR DESCRIPTION
[ApiSet schema map](https://msdn.microsoft.com/en-us/library/windows/desktop/hh802935(v=vs.85).aspx) is located inside every process virtual memory and can be located via the PEB : 

![image](https://user-images.githubusercontent.com/2520861/34252515-497b9fdc-e644-11e7-8abc-be01d5426d29.png)

