### PR TITLE
Alternative dbghelp.dll path

### DIFF
--- a/ProcessHacker/appsup.c
+++ b/ProcessHacker/appsup.c
@@ -1019,6 +1019,7 @@ PPH_STRING PhFindDbghelpPath(
     {
 #ifdef _WIN64
         { CSIDL_PROGRAM_FILESX86, L"\\Windows Kits\\10\\Debuggers\\x64\\dbghelp.dll" },
+        { CSIDL_PROGRAM_FILES, L"\\Windows Kits\\10\\Debuggers\\x64\\dbghelp.dll" },
         { CSIDL_PROGRAM_FILESX86, L"\\Windows Kits\\8.1\\Debuggers\\x64\\dbghelp.dll" },
         { CSIDL_PROGRAM_FILESX86, L"\\Windows Kits\\8.0\\Debuggers\\x64\\dbghelp.dll" },
         { CSIDL_PROGRAM_FILES, L"\\Debugging Tools for Windows (x64)\\dbghelp.dll" }


### PR DESCRIPTION
Sometimes is Windbg installed in "Program Files" (instead of "Program Files (x86)").