### PR TITLE
Improve behavior of "Protection" column in process tree

### DIFF
--- a/ProcessHacker/procprv.c
+++ b/ProcessHacker/procprv.c
@@ -1460,9 +1460,17 @@ VOID PhpFillProcessItem(
                 ProcessItem->Protection.Level = protection.Level;
             }
         }
+        else
+        {
+            // "emulate" PS_PROTECTION info for older OSes
+            if (ProcessItem->IsProtectedProcess)
+                ProcessItem->Protection.Type = PsProtectedTypeProtected;
+        }
     }
     else
     {
+        // we weren't able to get protection info
+        // lets signalize that with special value
         ProcessItem->Protection.Level = UCHAR_MAX;
     }
 

--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -2801,8 +2801,11 @@ BOOLEAN NTAPI PhpProcessTreeNewCallback(
                 break;
             case PHPRTLC_PROTECTION:
                 {
-                    PhMoveReference(&node->ProtectionText, PhGetProcessItemProtectionText(processItem));
-                    getCellText->Text = node->ProtectionText->sr;
+                    if (processItem->Protection.Level != 0 && processItem->Protection.Level != UCHAR_MAX)
+                    {
+                        PhMoveReference(&node->ProtectionText, PhGetProcessItemProtectionText(processItem));
+                        getCellText->Text = node->ProtectionText->sr;
+                    }
                 }
                 break;
             default:


### PR DESCRIPTION
The column will be rendered only if `processItem->Protection` is valid and non-zero.
That's the easy part.

To support also OSes older than Win8.1, I've added code to _emulate_ `PS_PROTECTION` on those systems. Basically if process is protected we will set `PsProtectedTypeProtected` type.
This unifies _protection_ processing across all OSes.

Though I had to explicitly check whether process is protected because `processItem->IsProtectedProcess` is initialized only later in the code. Maybe there is better/easier way to do this.

I'm also not sure whether to change `PhGetProcessItemProtectionText` too.
Basically it works well, but for  older OSes it uses `processItem->IsProtectedProcess` field. It looks a bit non-consistent. I see two solutions to this:
1. Simply check whether `processItem->Protection.Level` is non-zero (because now it is non-zero for protected processes).
2. Remove old OS branch completely and always format using `processItem->Protection` field.
Though this will change the output for old OSes a bit - instead of "Yes" there will be "Full" listed for protected processes. Maybe not a big deal.

What do you think?