### PR TITLE
GF Guard column improvements

### DIFF
--- a/ProcessHacker/include/procprv.h
+++ b/ProcessHacker/include/procprv.h
@@ -168,8 +168,9 @@ typedef struct _PH_PROCESS_ITEM
             ULONG IsProtectedProcess : 1;
             ULONG IsSecureProcess : 1;
             ULONG IsSubsystemProcess : 1;
+            ULONG IsControlFlowGuardEnabled : 1;
 
-            ULONG Spare : 15;
+            ULONG Spare : 14;
         };
     };
 
@@ -410,5 +411,9 @@ PhReferenceProcessItemForRecord(
     _In_ PPH_PROCESS_RECORD Record
     );
 // end_phapppub
+
+BOOLEAN PhProcessIsCFGuardEnabled(
+    _In_ HANDLE ProcessHandle
+);
 
 #endif

--- a/ProcessHacker/modlist.c
+++ b/ProcessHacker/modlist.c
@@ -774,11 +774,8 @@ BOOLEAN NTAPI PhpModuleTreeNewCallback(
                 }
                 break;
             case PHMOTLC_CFGUARD:
-                if (WindowsVersion >= WINDOWS_8_1)
-                {
-                    if (moduleItem->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
-                        PhInitializeStringRef(&getCellText->Text, L"CF Guard");
-                }
+                if (moduleItem->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
+                    PhInitializeStringRef(&getCellText->Text, L"CF Guard");
                 break;
             case PHMOTLC_LOADTIME:
                 {

--- a/ProcessHacker/modlist.c
+++ b/ProcessHacker/modlist.c
@@ -779,10 +779,6 @@ BOOLEAN NTAPI PhpModuleTreeNewCallback(
                     if (moduleItem->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
                         PhInitializeStringRef(&getCellText->Text, L"CF Guard");
                 }
-                else
-                {
-                    PhInitializeStringRef(&getCellText->Text, L"N/A");
-                }
                 break;
             case PHMOTLC_LOADTIME:
                 {

--- a/ProcessHacker/modprv.c
+++ b/ProcessHacker/modprv.c
@@ -354,6 +354,7 @@ VOID PhModuleProviderUpdate(
     PPH_MODULE_PROVIDER moduleProvider = (PPH_MODULE_PROVIDER)Object;
     PPH_LIST modules;
     ULONG i;
+    BOOLEAN cfGuardEnabled = FALSE;
 
     // If we didn't get a handle when we created the provider,
     // abort (unless this is the System process - in that case
@@ -444,6 +445,8 @@ VOID PhModuleProviderUpdate(
         }
     }
 
+    cfGuardEnabled = PhProcessIsCFGuardEnabled(moduleProvider->ProcessHandle);
+
     // Look for new modules.
     for (i = 0; i < modules->Count; i++)
     {
@@ -526,6 +529,10 @@ VOID PhModuleProviderUpdate(
                     PhUnloadRemoteMappedImage(&remoteMappedImage);
                 }
             }
+
+            // remove CF Guard flag if CFG mitigation is not enabled for the process
+            if (!cfGuardEnabled)
+                moduleItem->ImageDllCharacteristics &= ~IMAGE_DLLCHARACTERISTICS_GUARD_CF;
 
             if (NT_SUCCESS(PhQueryFullAttributesFileWin32(moduleItem->FileName->Buffer, &networkOpenInfo)))
             {

--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -1826,11 +1826,9 @@ END_SORT_FUNCTION
 
 BEGIN_SORT_FUNCTION(CfGuard)
 {
-    PhpUpdateProcessNodeImage(node1);
-    PhpUpdateProcessNodeImage(node2);
     sortResult = intcmp(
-        node1->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF,
-        node2->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF
+        node1->ProcessItem->IsControlFlowGuardEnabled,
+        node2->ProcessItem->IsControlFlowGuardEnabled
         );
 }
 END_SORT_FUNCTION
@@ -2736,13 +2734,8 @@ BOOLEAN NTAPI PhpProcessTreeNewCallback(
                 }
                 break;
             case PHPRTLC_CFGUARD:
-                PhpUpdateProcessNodeImage(node);
-
-                if (WindowsVersion >= WINDOWS_8_1)
-                {
-                    if (node->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
-                        PhInitializeStringRef(&getCellText->Text, L"CF Guard");
-                }
+                if (processItem->IsControlFlowGuardEnabled)
+                    PhInitializeStringRef(&getCellText->Text, L"CF Guard");
                 break;
             case PHPRTLC_TIMESTAMP:
                 PhpUpdateProcessNodeImage(node);

--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -2743,10 +2743,6 @@ BOOLEAN NTAPI PhpProcessTreeNewCallback(
                     if (node->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
                         PhInitializeStringRef(&getCellText->Text, L"CF Guard");
                 }
-                else
-                {
-                    PhInitializeStringRef(&getCellText->Text, L"N/A");
-                }
                 break;
             case PHPRTLC_TIMESTAMP:
                 PhpUpdateProcessNodeImage(node);


### PR DESCRIPTION
This PR introduces following changes to _CF Guard_ column handling:

- column is populated only if CFG is available (OS supports it)
- in process tree column is populated only if CFG mitigation is enabled for process
- in modules view column is populated only if CFG is enabled for process and module supports CFG

Basically _CF Guard_ column will now reflect real state of CFG. It should show information only if CFG is really active for given process/module.

I'm not exactly sure about _PhProcessIsCFGuardEnabled_ naming/placement. So I'd welcome any feedback on that.