### PR TITLE
Don't show border in main tabs

### DIFF
--- a/ProcessHacker/mainwnd.c
+++ b/ProcessHacker/mainwnd.c
@@ -394,6 +394,7 @@ VOID PhMwpInitializeControls(
     )
 {
     ULONG thinRows;
+    ULONG treelistBorder;
 
     TabControlHandle = CreateWindow(
         WC_TABCONTROL,
@@ -412,11 +413,12 @@ VOID PhMwpInitializeControls(
     BringWindowToTop(TabControlHandle);
 
     thinRows = PhGetIntegerSetting(L"ThinRows") ? TN_STYLE_THIN_ROWS : 0;
+    treelistBorder = PhGetIntegerSetting(L"TreeListBorderEnable") ? WS_BORDER : 0;
 
     PhMwpProcessTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | TN_STYLE_ANIMATE_DIVIDER | thinRows,
+        WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | TN_STYLE_ANIMATE_DIVIDER | thinRows | treelistBorder,
         0,
         0,
         3,
@@ -431,7 +433,7 @@ VOID PhMwpInitializeControls(
     PhMwpServiceTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows | treelistBorder,
         0,
         0,
         3,
@@ -446,7 +448,7 @@ VOID PhMwpInitializeControls(
     PhMwpNetworkTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows | treelistBorder,
         0,
         0,
         3,

--- a/ProcessHacker/mainwnd.c
+++ b/ProcessHacker/mainwnd.c
@@ -416,7 +416,7 @@ VOID PhMwpInitializeControls(
     PhMwpProcessTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_BORDER | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | TN_STYLE_ANIMATE_DIVIDER | thinRows,
+        WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | TN_STYLE_ANIMATE_DIVIDER | thinRows,
         0,
         0,
         3,
@@ -431,7 +431,7 @@ VOID PhMwpInitializeControls(
     PhMwpServiceTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_BORDER | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
         0,
         0,
         3,
@@ -446,7 +446,7 @@ VOID PhMwpInitializeControls(
     PhMwpNetworkTreeNewHandle = CreateWindow(
         PH_TREENEW_CLASSNAME,
         NULL,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_BORDER | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
         0,
         0,
         3,

--- a/ProcessHacker/settings.c
+++ b/ProcessHacker/settings.c
@@ -164,6 +164,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"TokenSplitterEnable", L"0");
     PhpAddIntegerSetting(L"TokenSplitterPosition", L"150");
     PhpAddStringSetting(L"TokenPrivilegesListViewColumns", L"");
+    PhpAddIntegerSetting(L"TreeListBorderEnable", L"1");
     PhpAddIntegerSetting(L"UpdateInterval", L"3e8"); // 1000ms
     PhpAddIntegerSetting(L"WmiProviderEnableHiddenMenu", L"0");
     PhpAddStringSetting(L"WmiProviderListViewColumns", L"");

--- a/plugins/ExtendedTools/disktab.c
+++ b/plugins/ExtendedTools/disktab.c
@@ -91,12 +91,14 @@ BOOLEAN EtpDiskPageCallback(
             if (EtEtwEnabled)
             {
                 ULONG thinRows;
+                ULONG treelistBorder;
 
                 thinRows = PhGetIntegerSetting(L"ThinRows") ? TN_STYLE_THIN_ROWS : 0;
+                treelistBorder = PhGetIntegerSetting(L"TreeListBorderEnable") ? WS_BORDER : 0;
                 hwnd = CreateWindow(
                     PH_TREENEW_CLASSNAME,
                     NULL,
-                    WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+                    WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows | treelistBorder,
                     0,
                     0,
                     3,

--- a/plugins/ExtendedTools/disktab.c
+++ b/plugins/ExtendedTools/disktab.c
@@ -96,7 +96,7 @@ BOOLEAN EtpDiskPageCallback(
                 hwnd = CreateWindow(
                     PH_TREENEW_CLASSNAME,
                     NULL,
-                    WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_BORDER | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
+                    WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TN_STYLE_ICONS | TN_STYLE_DOUBLE_BUFFERED | thinRows,
                     0,
                     0,
                     3,


### PR DESCRIPTION
I'd like to propose this cosmetic change. Border around list/tree views in main tabs looks a bit distracting. The window looks more clean and modern without the border, imho.

Though it is matter of taste, so not sure you will like it.

Original:
![ph-main-border](https://user-images.githubusercontent.com/2453094/34917883-4b70c216-f94c-11e7-846b-06739cb542d1.png)
Without border:
![ph-main-no-border](https://user-images.githubusercontent.com/2453094/34917884-579a3770-f94c-11e7-81ca-0dc3965046aa.png)
