### PR TITLE
Get proper information for kernel modules

### DIFF
--- a/phlib/include/mapimg.h
+++ b/phlib/include/mapimg.h
@@ -156,6 +156,23 @@ PhLoadRemoteMappedImage(
     _Out_ PPH_REMOTE_MAPPED_IMAGE RemoteMappedImage
     );
 
+typedef NTSTATUS (NTAPI *PPH_READ_VIRTUAL_MEMORY)(
+    _In_ HANDLE ProcessHandle,
+    _In_opt_ PVOID BaseAddress,
+    _Out_writes_bytes_(BufferSize) PVOID Buffer,
+    _In_ SIZE_T BufferSize,
+    _Out_opt_ PSIZE_T NumberOfBytesRead
+    );
+
+NTSTATUS
+NTAPI
+PhLoadRemoteMappedImageEx(
+    _In_ HANDLE ProcessHandle,
+    _In_ PVOID ViewBase,
+    _In_ PPH_READ_VIRTUAL_MEMORY ReadVirtualMemory,
+    _Out_ PPH_REMOTE_MAPPED_IMAGE RemoteMappedImage
+    );
+
 NTSTATUS
 NTAPI
 PhUnloadRemoteMappedImage(

--- a/phlib/mapimg.c
+++ b/phlib/mapimg.c
@@ -502,6 +502,16 @@ NTSTATUS PhLoadRemoteMappedImage(
     _Out_ PPH_REMOTE_MAPPED_IMAGE RemoteMappedImage
     )
 {
+    return PhLoadRemoteMappedImageEx(ProcessHandle, ViewBase, NtReadVirtualMemory, RemoteMappedImage);
+}
+
+NTSTATUS PhLoadRemoteMappedImageEx(
+    _In_ HANDLE ProcessHandle,
+    _In_ PVOID ViewBase,
+    _In_ PPH_READ_VIRTUAL_MEMORY ReadVirtualMemory,
+    _Out_ PPH_REMOTE_MAPPED_IMAGE RemoteMappedImage
+    )
+{
     NTSTATUS status;
     IMAGE_DOS_HEADER dosHeader;
     ULONG ntHeadersOffset;
@@ -510,7 +520,7 @@ NTSTATUS PhLoadRemoteMappedImage(
 
     RemoteMappedImage->ViewBase = ViewBase;
 
-    status = NtReadVirtualMemory(
+    status = ReadVirtualMemory(
         ProcessHandle,
         ViewBase,
         &dosHeader,
@@ -533,7 +543,7 @@ NTSTATUS PhLoadRemoteMappedImage(
     if (ntHeadersOffset == 0 || ntHeadersOffset >= 0x10000000)
         return STATUS_INVALID_IMAGE_FORMAT;
 
-    status = NtReadVirtualMemory(
+    status = ReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(ViewBase, ntHeadersOffset),
         &ntHeaders,
@@ -569,7 +579,7 @@ NTSTATUS PhLoadRemoteMappedImage(
 
     RemoteMappedImage->NtHeaders = PhAllocate(ntHeadersSize);
 
-    status = NtReadVirtualMemory(
+    status = ReadVirtualMemory(
         ProcessHandle,
         PTR_ADD_OFFSET(ViewBase, ntHeadersOffset),
         RemoteMappedImage->NtHeaders,


### PR DESCRIPTION
It is not possible to read kernel memory from user-mode. Though we can read headers directly from files (in case of kernel modules).

This will fix "CF Guard", "ASLR" and "Entry point" columns for kernel modules.