### PR TITLE
Make PH_IMAGE_RESOURCE_ENTRY.Data return a VA instead of a RVA

### DIFF
--- a/phlib/mapimg.c
+++ b/phlib/mapimg.c
@@ -1688,7 +1688,7 @@ NTSTATUS PhGetMappedImageResources(
                 Resources->ResourceEntries[resourceIndex].Type = NAME_FROM_RESOURCE_ENTRY(resourceDirectory, resourceType);
                 Resources->ResourceEntries[resourceIndex].Name = NAME_FROM_RESOURCE_ENTRY(resourceDirectory, resourceName);
                 Resources->ResourceEntries[resourceIndex].Language = NAME_FROM_RESOURCE_ENTRY(resourceDirectory, resourceLanguage);
-                Resources->ResourceEntries[resourceIndex].Data = PTR_ADD_OFFSET(MappedImage->ViewBase, resourceData->OffsetToData);
+                Resources->ResourceEntries[resourceIndex].Data = PhMappedImageRvaToVa(MappedImage, resourceData->OffsetToData, NULL);
                 Resources->ResourceEntries[resourceIndex++].Size = resourceData->Size;
             }
         }


### PR DESCRIPTION
`PIMAGE_RESOURCE_DATA_ENTRY.Data` return a RVA per the PE-COFF specification, so we need to convert it into a VA before using it.

Spec (http://www.osdever.net/documents/PECOFF.pdf) :

![capture](https://user-images.githubusercontent.com/2520861/35187012-9fc39200-fe1d-11e7-8c07-5e6e710fcb06.PNG)

I've tested on my own, it works as intended (`PH_IMAGE_RESOURCE_ENTRY.Data` now directly points to the resource data memory area)