### PR TITLE
Lost check for abandoned mutexes

### DIFF
--- a/phlib/util.c
+++ b/phlib/util.c
@@ -2301,7 +2301,10 @@ NTSTATUS PhWaitForMultipleObjectsAndPump(
             QS_ALLEVENTS
             );
 
-        if (status >= STATUS_WAIT_0 && status < (NTSTATUS)(STATUS_WAIT_0 + NumberOfHandles))
+        if (
+            status >= STATUS_WAIT_0 && status < (NTSTATUS)(STATUS_WAIT_0 + NumberOfHandles) ||
+            status >= STATUS_ABANDONED_WAIT_0  && status < (NTSTATUS)(STATUS_ABANDONED_WAIT_0 + NumberOfHandles)
+            )
         {
             return status;
         }


### PR DESCRIPTION
[MsgWaitForMultipleObjects](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684242(v=vs.85).aspx) can succeed with return value from `WAIT_ABANDONED_0` to `(WAIT_ABANDONED_0 + nCount – 1)` if at least one of the specified objects is an abandoned mutex.